### PR TITLE
Update async_ws.py

### DIFF
--- a/src/surrealdb/connections/async_ws.py
+++ b/src/surrealdb/connections/async_ws.py
@@ -99,6 +99,8 @@ class AsyncWsSurrealConnection(AsyncTemplate, UtilsMixin):
         if response.get("id") is None:
             raise Exception(f"no id signing in: {response}")
         self.id = response["id"]
+        return self.token
+        
 
     async def query(self, query: str, params: Optional[dict] = None) -> dict:
         if params is None:


### PR DESCRIPTION
## Description
Added missing return statement in the `signin()` method to return the authentication token.

## Problem
The `signin()` method had a return type annotation of `str` but wasn't actually returning the token, making it impossible for users to capture the token value directly from the `signin()` call.

## Changes
- Added `return self.token` statement to the `signin()` method

## Testing
- Verified that the token is now properly returned when calling `signin()`
- Behavior remains backwards compatible as the token is still stored in `self.token`